### PR TITLE
added a route for updating a recipe using the same form as create

### DIFF
--- a/src/app/recipe/edit/[firebaseKey]/page.js
+++ b/src/app/recipe/edit/[firebaseKey]/page.js
@@ -1,0 +1,24 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { getSingleRecipe } from '@/api/recipeData';
+import RecipeForm from '@/components/forms/RecipeForm';
+import PropTypes from 'prop-types';
+
+export default function UpdateRecipePage({ params }) {
+  const [editItem, setEditItem] = useState({});
+  // grab the firebasekey
+  const { firebaseKey } = params;
+
+  // make a call to the API to get the recipe data
+  useEffect(() => {
+    getSingleRecipe(firebaseKey).then(setEditItem);
+  }, [firebaseKey]);
+
+  // pass object to form
+  return <RecipeForm obj={editItem} />;
+}
+
+UpdateRecipePage.propTypes = {
+  params: PropTypes.objectOf({}).isRequired,
+};

--- a/src/components/forms/RecipeForm.js
+++ b/src/components/forms/RecipeForm.js
@@ -73,7 +73,6 @@ function RecipeForm({ obj = initialState }) {
       createRecipe(payload).then(({ name }) => {
         const patchPayload = { firebaseKey: name };
         updateRecipe(patchPayload).then(() => {
-          // Handle recipeIngredients here (you can send the ingredientLines data to the backend)
           router.push('/');
         });
       });


### PR DESCRIPTION
## Detailed Description
Added a route for updating a recipe using the same form as the one used to create a recipe. This allows users to edit existing recipes by pre-filling the form with the current recipe data, which can then be updated and saved.

## How to Test
1. Click the "Edit" button on a recipe card to open the update form.
2. Verify that the form is pre-filled with the existing recipe data.
3. Modify the recipe data and submit the form.
4. Confirm that the recipe is updated correctly on the recipe card.

## Motivation and Context
This change is required to allow users to update recipes they have already created. Without this functionality, users would have to delete and recreate their recipes to make any changes.

## Screenshots (if applicable)

## Types of Changes
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💡 Improvement
- [ ] ⚠️ Breaking change
- [ ] 🧹 Code cleanup
- [ ] 📖 Documentation
